### PR TITLE
[FIX] typo .Config.Env

### DIFF
--- a/Utilisation de Docker/06. Gérer les conteneurs.md
+++ b/Utilisation de Docker/06. Gérer les conteneurs.md
@@ -390,7 +390,7 @@ _Ces variables sont spécifiques à l'image_
 
 Nous pouvons vérifier les variables d'environnement via `docker container inspect lutim`, mais cette commande retourne toute la configuration de notre conteneur, nous allons donc le formatter :
 ```shell
-$ docker container inspect -f '{{.Config.env}}' lutim
+$ docker container inspect -f '{{.Config.Env}}' lutim
 [UID=1000 GID=1000 SECRET=mysecretcookie WEBROOT=/images PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin CONTACT=contact@domain.tld MAX_FILE_SIZE=10000000000 DEFAULT_DELAY=1 MAX_DELAY=0]
 ```
 Nous avons ici également des variables que nous n'avons pas indiqué lors du lancement du conteneur, mais c'est normal, lors de la création d'une image, nous pouvons mettre des valeurs par défaut (nous verrons également ceci dans la partie **Créer une image**)


### PR DESCRIPTION
**Without that patch**

call :  ``docker container inspect -f '{{.Config.Env}}' lutim``
Result is : ``Template parsing error: template: :1:9: executing "" at <.Config.env>: map has no entry for key "env"``

**With that patch**
 
Result is : ``[UID=1000 GID=1000 SECRET=mysecretcookie WEBROOT=/images PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin CONTACT=contact@domain.tld MAX_FILE_SIZE=10000000000 DEFAULT_DELAY=1 MAX_DELAY=0]``

kind regard, and thanks for this awsome tutorial.